### PR TITLE
fix: http / https default ports, try catch delete cookies

### DIFF
--- a/packages/http-utils/src/index.ts
+++ b/packages/http-utils/src/index.ts
@@ -301,7 +301,7 @@ export function getHost (addresses: URL | Multiaddr[], headers: Headers): string
 
   if (addresses instanceof URL) {
     host = addresses.hostname
-    port = parseInt(addresses.port, 10)
+    port = addresses.port === '' ? (addresses.protocol === 'https:' ? 443 : 80) : parseInt(addresses.port, 10)
     protocol = addresses.protocol
   }
 
@@ -362,11 +362,11 @@ export function getHost (addresses: URL | Multiaddr[], headers: Headers): string
 
   if (isValidHost(host)) {
     // add port if not standard
-    if (protocol === 'http:' && port !== 80) {
+    if (protocol === 'http:' && !Number.isNaN(port) && port !== 80) {
       host = `${host}:${port}`
     }
 
-    if (protocol === 'https:' && port !== 443) {
+    if (protocol === 'https:' && !Number.isNaN(port) && port !== 443) {
       host = `${host}:${port}`
     }
 

--- a/packages/http-utils/test/index.spec.ts
+++ b/packages/http-utils/test/index.spec.ts
@@ -1,5 +1,14 @@
-describe('@libp2p/http-utils', () => {
-  it('should run a test', () => {
+import { getHost } from '../src/index.js'
+import { expect } from 'aegir/chai'
 
+describe('@libp2p/http-utils', () => {
+  it('does not append NaN for default URL ports', () => {
+    expect(getHost(new URL('https://registration.libp2p.direct/v1/_acme-challenge'), new Headers())).to.equal('registration.libp2p.direct')
+    expect(getHost(new URL('http://example.com/path'), new Headers())).to.equal('example.com')
+  })
+
+  it('appends explicit non-standard URL ports', () => {
+    expect(getHost(new URL('https://example.com:8443/path'), new Headers())).to.equal('example.com:8443')
+    expect(getHost(new URL('http://example.com:8080/path'), new Headers())).to.equal('example.com:8080')
   })
 })

--- a/packages/http-utils/test/index.spec.ts
+++ b/packages/http-utils/test/index.spec.ts
@@ -1,5 +1,5 @@
-import { getHost } from '../src/index.js'
 import { expect } from 'aegir/chai'
+import { getHost } from '../src/index.js'
 
 describe('@libp2p/http-utils', () => {
   it('does not append NaN for default URL ports', () => {

--- a/packages/http/src/middleware/cookies.ts
+++ b/packages/http/src/middleware/cookies.ts
@@ -95,7 +95,11 @@ export class Cookies implements Middleware {
  */
 function removeSetCookie (response: Response): Response {
   if (response.headers.has('set-cookie')) {
-    response.headers.delete('set-cookie')
+    try {
+      response.headers.delete('set-cookie')
+    } catch {
+      // Native fetch response headers can be immutable in Node/undici.
+    }
   }
 
   return response

--- a/packages/http/test/index.spec.ts
+++ b/packages/http/test/index.spec.ts
@@ -1,5 +1,25 @@
-describe('@libp2p/http', () => {
-  it('should run a test', () => {
+import { Cookies } from '../src/middleware/cookies.js'
+import { expect } from 'aegir/chai'
 
+describe('@libp2p/http', () => {
+  it('ignores immutable set-cookie response headers', async () => {
+    const cookies = new Cookies({
+      logger: {
+        forComponent: () => () => {}
+      }
+    } as any)
+    const response = new Response()
+
+    Object.defineProperty(response, 'headers', {
+      value: {
+        getSetCookie: () => ['sid=abc'],
+        has: (name: string) => name === 'set-cookie',
+        delete: () => { throw new TypeError('immutable') }
+      }
+    })
+
+    await expect(cookies.processResponse(new URL('https://example.com'), {
+      headers: new Headers({ origin: 'https://example.com' })
+    } as any, response)).to.eventually.be.undefined()
   })
 })

--- a/packages/http/test/index.spec.ts
+++ b/packages/http/test/index.spec.ts
@@ -2,7 +2,7 @@ import { Cookies } from '../src/middleware/cookies.js'
 import { expect } from 'aegir/chai'
 
 describe('@libp2p/http', () => {
-  it('ignores immutable set-cookie response headers', async () => {
+  it('ignores failures when stripping set-cookie from immutable response headers', async () => {
     const cookies = new Cookies({
       logger: {
         forComponent: () => () => {}

--- a/packages/http/test/index.spec.ts
+++ b/packages/http/test/index.spec.ts
@@ -1,5 +1,5 @@
-import { Cookies } from '../src/middleware/cookies.js'
 import { expect } from 'aegir/chai'
+import { Cookies } from '../src/middleware/cookies.js'
 
 describe('@libp2p/http', () => {
   it('ignores failures when stripping set-cookie from immutable response headers', async () => {


### PR DESCRIPTION
## Description

- Adds default port numbers for http and https
- Try catch deleting Node/Undici immutable cookies

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works